### PR TITLE
Adding pynio to the environment file

### DIFF
--- a/pangeo-notebook/environment.yml
+++ b/pangeo-notebook/environment.yml
@@ -55,6 +55,7 @@ dependencies:
  - pyarrow
  - pycamhd
  - pydap
+ - pynio
  - pystac
  - python-blosc
  - python-gist


### PR DESCRIPTION
I have been trying to install pynio locally on AWS (`conda install -c conda-forge pynio`) with no luck - the solving fails at first and then it spins for a long time.

I know about `cfgrib` as an alternative engine to read `grib` files, but `cfgrib` does not like my grib files - `pynio` does (I tested it on another machine).